### PR TITLE
feat(BusinessPage): reduce side margin on Nearby Places section on xs screens

### DIFF
--- a/src/pages/Business/BusinessPage.tsx
+++ b/src/pages/Business/BusinessPage.tsx
@@ -49,7 +49,7 @@ const BusinessPage = () => {
         flexDirection={{ _: 'column', lg: 'row' }}
         justifyContent="space-between"
         my={8}
-        mx={12}
+        mx={{ _: 2, sm: 12 }}
       >
         <SectionGroup justifyContent="space-around" flex={4} mr={5}>
           {loading ? (

--- a/src/pages/Business/__snapshots__/BusinessPage.test.tsx.snap
+++ b/src/pages/Business/__snapshots__/BusinessPage.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`BusinessPage Nearby Places should render loading screen 1`] = `
       </div>
     </div>
     <div
-      class="sc-cxabCf TyWjI"
+      class="sc-cxabCf cTSDup"
     >
       <div
         class="sc-cxabCf fBBkYE"
@@ -242,7 +242,7 @@ exports[`BusinessPage should match snapshot 1`] = `
       />
     </div>
     <div
-      class="sc-cxabCf TyWjI"
+      class="sc-cxabCf cTSDup"
     >
       <div
         class="sc-cxabCf fBBkYE"


### PR DESCRIPTION
## Summary
Use smaller side margin on screens smaller than xs (640px)

Closes: #73 

## Preview

https://user-images.githubusercontent.com/14312677/178248280-3f423762-0106-4940-8028-a04c6158aa57.mp4


